### PR TITLE
Fix for GamedoniaSDK web url.

### DIFF
--- a/client/app/sdks.js
+++ b/client/app/sdks.js
@@ -411,7 +411,7 @@
       founded: 2012,
       hq: "Barcelona",
       c: "es",
-      url: "https://www.gamedonia.com/",
+      url: "http://www.gamedonia.com/",
       github: "https://github.com/gamedonia",
       download: "https://docs.gamedonia.com/get-started",
       platforms: ['ios', 'unity', 'cocos2dx', 'android', 'air'],


### PR DESCRIPTION
Hi,

yesterday I made a mistake. I am working on our development environment using SSL for the whole site but the public site does not has SSL enabled.

Please fix this when possible.

Regards